### PR TITLE
fix(139): update family cloud API

### DIFF
--- a/drivers/139/driver.go
+++ b/drivers/139/driver.go
@@ -108,9 +108,9 @@ func (d *Yun139) Link(ctx context.Context, file model.Obj, args model.LinkArgs) 
 	case MetaPersonalNew:
 		url, err = d.personalGetLink(file.GetID())
 	case MetaPersonal:
-		fallthrough
-	case MetaFamily:
 		url, err = d.getLink(file.GetID())
+	case MetaFamily:
+		url, err = d.familyGetLink(file.GetID(), file.GetPath())
 	default:
 		return nil, errs.NotImplement
 	}

--- a/drivers/139/util.go
+++ b/drivers/139/util.go
@@ -220,10 +220,11 @@ func (d *Yun139) familyGetFiles(catalogID string) ([]model.Obj, error) {
 			"sortDirection": 1,
 		})
 		var resp QueryContentListResp
-		_, err := d.post("/orchestration/familyCloud/content/v1.0/queryContentList", data, &resp)
+		_, err := d.post("/orchestration/familyCloud-rebuild/content/v1.2/queryContentList", data, &resp)
 		if err != nil {
 			return nil, err
 		}
+		path := resp.Data.Path
 		for _, catalog := range resp.Data.CloudCatalogList {
 			f := model.Object{
 				ID:       catalog.CatalogID,
@@ -243,6 +244,7 @@ func (d *Yun139) familyGetFiles(catalogID string) ([]model.Obj, error) {
 					Size:     content.ContentSize,
 					Modified: getTime(content.LastUpdateTime),
 					Ctime:    getTime(content.CreateTime),
+					Path:     path,
 				},
 				Thumbnail: model.Thumbnail{Thumbnail: content.ThumbnailURL},
 				//Thumbnail: content.BigthumbnailURL,
@@ -266,6 +268,18 @@ func (d *Yun139) getLink(contentId string) (string, error) {
 			"accountType": 1,
 		},
 	}
+	res, err := d.post("/orchestration/personalCloud/uploadAndDownload/v1.0/downloadRequest",
+		data, nil)
+	if err != nil {
+		return "", err
+	}
+	return jsoniter.Get(res, "data", "downloadURL").ToString(), nil
+}
+func (d *Yun139) familyGetLink(contentId string, path string) (string, error) {
+	data := d.newJson(base.Json{
+		"contentID": contentId,
+		"path":       path,
+	})
 	res, err := d.post("/orchestration/personalCloud/uploadAndDownload/v1.0/downloadRequest",
 		data, nil)
 	if err != nil {

--- a/drivers/terabox/types.go
+++ b/drivers/terabox/types.go
@@ -95,3 +95,7 @@ type PrecreateResp struct {
 type CheckLoginResp struct {
 	Errno int `json:"errno"`
 }
+
+type LocateUploadResp struct {
+	Host string `json:"host"`
+}

--- a/drivers/terabox/util.go
+++ b/drivers/terabox/util.go
@@ -14,6 +14,7 @@ import (
 	"github.com/alist-org/alist/v3/internal/model"
 	"github.com/alist-org/alist/v3/pkg/utils"
 	"github.com/go-resty/resty/v2"
+	log "github.com/sirupsen/logrus"
 )
 
 func getStrBetween(raw, start, end string) string {
@@ -28,11 +29,11 @@ func getStrBetween(raw, start, end string) string {
 }
 
 func (d *Terabox) resetJsToken() error {
-	u := "https://www.terabox.com/main"
+	u := d.base_url
 	res, err := base.RestyClient.R().SetHeaders(map[string]string{
 		"Cookie":           d.Cookie,
 		"Accept":           "application/json, text/plain, */*",
-		"Referer":          "https://www.terabox.com/",
+		"Referer":          d.base_url,
 		"User-Agent":       base.UserAgent,
 		"X-Requested-With": "XMLHttpRequest",
 	}).Get(u)
@@ -48,12 +49,12 @@ func (d *Terabox) resetJsToken() error {
 	return nil
 }
 
-func (d *Terabox) request(furl string, method string, callback base.ReqCallback, resp interface{}, noRetry ...bool) ([]byte, error) {
+func (d *Terabox) request(rurl string, method string, callback base.ReqCallback, resp interface{}, noRetry ...bool) ([]byte, error) {
 	req := base.RestyClient.R()
 	req.SetHeaders(map[string]string{
 		"Cookie":           d.Cookie,
 		"Accept":           "application/json, text/plain, */*",
-		"Referer":          "https://www.terabox.com/",
+		"Referer":          d.base_url,
 		"User-Agent":       base.UserAgent,
 		"X-Requested-With": "XMLHttpRequest",
 	})
@@ -70,7 +71,7 @@ func (d *Terabox) request(furl string, method string, callback base.ReqCallback,
 	if resp != nil {
 		req.SetResult(resp)
 	}
-	res, err := req.Execute(method, furl)
+	res, err := req.Execute(method, d.base_url+rurl)
 	if err != nil {
 		return nil, err
 	}
@@ -82,14 +83,20 @@ func (d *Terabox) request(furl string, method string, callback base.ReqCallback,
 			return nil, err
 		}
 		if !utils.IsBool(noRetry...) {
-			return d.request(furl, method, callback, resp, true)
+			return d.request(rurl, method, callback, resp, true)
 		}
+	} else if errno == -6 {
+		log.Debugln(res.Header())
+		d.url_domain_prefix = res.Header()["Url-Domain-Prefix"][0]
+		d.base_url = "https://" + d.url_domain_prefix + ".terabox.com"
+		log.Debugln("Redirect base_url to", d.base_url)
+		return d.request(rurl, method, callback, resp, noRetry...)
 	}
 	return res.Body(), nil
 }
 
 func (d *Terabox) get(pathname string, params map[string]string, resp interface{}) ([]byte, error) {
-	return d.request("https://www.terabox.com"+pathname, http.MethodGet, func(req *resty.Request) {
+	return d.request(pathname, http.MethodGet, func(req *resty.Request) {
 		if params != nil {
 			req.SetQueryParams(params)
 		}
@@ -97,11 +104,20 @@ func (d *Terabox) get(pathname string, params map[string]string, resp interface{
 }
 
 func (d *Terabox) post(pathname string, params map[string]string, data interface{}, resp interface{}) ([]byte, error) {
-	return d.request("https://www.terabox.com"+pathname, http.MethodPost, func(req *resty.Request) {
+	return d.request(pathname, http.MethodPost, func(req *resty.Request) {
 		if params != nil {
 			req.SetQueryParams(params)
 		}
 		req.SetBody(data)
+	}, resp)
+}
+
+func (d *Terabox) post_form(pathname string, params map[string]string, data map[string]string, resp interface{}) ([]byte, error) {
+	return d.request(pathname, http.MethodPost, func(req *resty.Request) {
+		if params != nil {
+			req.SetQueryParams(params)
+		}
+		req.SetFormData(data)
 	}, resp)
 }
 
@@ -235,15 +251,6 @@ func (d *Terabox) manage(opera string, filelist interface{}) ([]byte, error) {
 	}
 	data := fmt.Sprintf("async=0&filelist=%s&ondup=newcopy", encodeURIComponent(string(marshal)))
 	return d.post("/api/filemanager", params, data, nil)
-}
-
-func (d *Terabox) create(path string, size int64, isdir int, uploadid, block_list string) ([]byte, error) {
-	params := map[string]string{}
-	data := fmt.Sprintf("path=%s&size=%d&isdir=%d", encodeURIComponent(path), size, isdir)
-	if uploadid != "" {
-		data += fmt.Sprintf("&uploadid=%s&block_list=%s", uploadid, block_list)
-	}
-	return d.post("/api/create", params, data, nil)
 }
 
 func encodeURIComponent(str string) string {


### PR DESCRIPTION
- Add new function familyGetLink to handle family cloud file links
- Update Link function to use new familyGetLink for MetaFamily type
- Modify familyGetFiles to include file path information
- Update API endpoint for family cloud content query